### PR TITLE
[REVIEW] feature/sync_schemas

### DIFF
--- a/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/CalciteApplication.java
+++ b/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/CalciteApplication.java
@@ -201,7 +201,7 @@ public class CalciteApplication {
 		
 		if (isTCP == true) {
 			final Integer tcpPort = calciteApplicationOptions.tcpPort();
-			service = new TCPService(tcpPort, dataDirectory);
+			service = new TCPService(tcpPort, dataDirectory, calciteApplicationOptions.getOrchestratorIp(), calciteApplicationOptions.getOrchestratorPort());
 		} else {
 			final String unixSocketPath = calciteApplicationOptions.unixSocketPath();
 			service = new UnixService(unixSocketPath, dataDirectory);
@@ -228,6 +228,16 @@ public class CalciteApplication {
 				.desc("Unix socket file path for this service").build();
 		options.addOption(unixSocketPathOption);
 
+		final String orchestratorIpDefaultValue = "127.0.0.1";
+		final Option orchestratorIp = Option.builder("oip").required(false).longOpt("orch_ip").hasArg()
+				.argName("HOSTNAME").desc("Orchestrator hostname").build();
+		options.addOption(orchestratorIp);
+
+		final String orchestratorPortDefaultValue = "8889";
+		final Option orchestratorPort = Option.builder("oport").required(false).longOpt("orch_port").hasArg()
+				.argName("INTEGER").desc("Orchestrator port").build();
+		options.addOption(orchestratorPort);
+
 		try {
 			final CommandLineParser commandLineParser = new DefaultParser();
 			final CommandLine commandLine = commandLineParser.parse(options, arguments);
@@ -250,7 +260,10 @@ public class CalciteApplication {
 			CalciteApplicationOptions calciteApplicationOptions = null;
 			
 			if (isTCP) {
-				calciteApplicationOptions = new CalciteApplicationOptions(tcpPort, dataDirectory);
+				final String orchIp = commandLine.getOptionValue(orchestratorIp.getLongOpt(), orchestratorIpDefaultValue);
+				final Integer orchPort = Integer.valueOf(commandLine.getOptionValue(orchestratorPort.getLongOpt(), orchestratorPortDefaultValue));
+
+				calciteApplicationOptions = new CalciteApplicationOptions(tcpPort, dataDirectory, orchIp, orchPort);
 			} else {
 				calciteApplicationOptions = new CalciteApplicationOptions(unixSocketPath, dataDirectory);
 			}
@@ -274,11 +287,15 @@ public class CalciteApplication {
 		private String unixSocketPath = null;
 		private Integer tcpPort = null;
 		private final String dataDirectory;
+		private String  orchestratorIp = null;
+		private Integer orchestratorPort = null;
 
 		//ctor for TCP
-		public CalciteApplicationOptions(final Integer tcpPort, final String dataDirectory) {
+		public CalciteApplicationOptions(final Integer tcpPort, final String dataDirectory, final String orchestratorIp, final Integer orchestratorPort) {
 			this.tcpPort = tcpPort;
 			this.dataDirectory = dataDirectory;
+			this.orchestratorIp = orchestratorIp;
+			this.orchestratorPort = orchestratorPort;
 		}
 		
 		//ctor for Unix Socket
@@ -305,6 +322,14 @@ public class CalciteApplication {
 
 		public String dataDirectory() {
 			return dataDirectory;
+		}
+
+		public String getOrchestratorIp() {
+			return orchestratorIp;
+		}
+
+		public Integer getOrchestratorPort() {
+			return orchestratorPort;
 		}
 	}
 }

--- a/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/CalciteService.java
+++ b/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/CalciteService.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import com.blazingdb.protocol.IService;
 import org.apache.calcite.plan.RelOptUtil;
 
 import com.blazingdb.calcite.application.Chrono.Chronometer;
@@ -23,6 +24,22 @@ import blazingdb.protocol.calcite.MessageType;
 //NOTE this is a static class only thats why the ctr is private and the def is final
 public final class CalciteService {
 	private CalciteService() {
+	}
+
+
+	public static  ByteBuffer processRequestSample(ByteBuffer buffer, final String dataDirectory) {
+		DMLRequestMessage request = new DMLRequestMessage(buffer);
+		System.out.println("##ByteBuffer statement_:" + request.getQuery());
+
+		String logicalPlan = "LogicalUnion(all=[false])\n" +
+				"  LogicalUnion(all=[false])\n" +
+				"    LogicalProject(EXPR$0=[$1], join_x=[$0])\n" +
+				"      LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])\n" +
+				"        LogicalProject(join_x=[$4], join_x0=[$7])\n" +
+				"          LogicalJoin(condition=[=($7, $0)], joinType=[inner])\n";
+
+		DMLResponseMessage response = new DMLResponseMessage(logicalPlan, 0);
+		return response.getBufferData();
 	}
 
 	public static ByteBuffer processRequest(ByteBuffer buffer, final String dataDirectory) {
@@ -65,7 +82,6 @@ public final class CalciteService {
 			} catch (Exception e) {
 				ResponseErrorMessage error = new ResponseErrorMessage("Could not create table");
 				response = new ResponseMessage(Status.Error, error.getBufferData());
-
 			}
 			return response.getBufferData();
 		} else if (requestMessage.getHeaderType() == MessageType.DDL_DROP_TABLE) {

--- a/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/CalciteService.java
+++ b/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/CalciteService.java
@@ -25,23 +25,7 @@ import blazingdb.protocol.calcite.MessageType;
 public final class CalciteService {
 	private CalciteService() {
 	}
-
-
-	public static  ByteBuffer processRequestSample(ByteBuffer buffer, final String dataDirectory) {
-		DMLRequestMessage request = new DMLRequestMessage(buffer);
-		System.out.println("##ByteBuffer statement_:" + request.getQuery());
-
-		String logicalPlan = "LogicalUnion(all=[false])\n" +
-				"  LogicalUnion(all=[false])\n" +
-				"    LogicalProject(EXPR$0=[$1], join_x=[$0])\n" +
-				"      LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])\n" +
-				"        LogicalProject(join_x=[$4], join_x0=[$7])\n" +
-				"          LogicalJoin(condition=[=($7, $0)], joinType=[inner])\n";
-
-		DMLResponseMessage response = new DMLResponseMessage(logicalPlan, 0);
-		return response.getBufferData();
-	}
-
+	
 	public static ByteBuffer processRequest(ByteBuffer buffer, final String dataDirectory) {
 		Chronometer chronometer = Chronometer.makeStarted();
 

--- a/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/TCPClient.java
+++ b/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/TCPClient.java
@@ -1,0 +1,58 @@
+package com.blazingdb.calcite.application;
+
+ import java.io.IOException;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import java.io.*;
+
+import com.blazingdb.protocol.util.ByteBufferUtil;
+
+public class TCPClient {
+    String hostname;
+    int port;
+    public TCPClient(String hostname, int port){
+        this.hostname = hostname;
+        this.port = port;
+    }
+
+    public byte[] send(byte[] message) {
+        byte[] result = null;
+        try  (Socket socket = new Socket(hostname, port)) {
+            OutputStream out = socket.getOutputStream();
+            try {
+                int length = message.length;
+                ByteBuffer buffer = ByteBuffer.allocate(4);
+                buffer.order(ByteOrder.LITTLE_ENDIAN);
+                buffer.putInt(length);
+                buffer.rewind();
+                out.write(buffer.array());
+
+                out.write(message);
+                InputStream inputStream =socket.getInputStream();
+
+                ByteBuffer bufferInt = ByteBuffer.allocate(4);
+                bufferInt.order(ByteOrder.LITTLE_ENDIAN);
+                inputStream.read(bufferInt.array());
+                bufferInt.rewind();
+                length = bufferInt.getInt();
+                result = new byte[length];
+                inputStream.read(result);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } catch(UnknownHostException u) {
+            System.err.println("UnknownHostException reading from/writing to socket-orchestrator, e=" + u);
+        }catch(IOException i) {
+            System.err.println("IOException reading from/writing to socket-orchestrator, e=" + i);
+         }
+        return result;
+    }
+
+    public ByteBuffer send(ByteBuffer message) {
+        return ByteBuffer.wrap(send(ByteBufferUtil.getByteArrayFromByteBuffer(message).array()));
+    }
+}
+

--- a/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/TCPService.java
+++ b/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/application/TCPService.java
@@ -10,24 +10,78 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Scanner;
+
+import blazingdb.protocol.Status;
+import blazingdb.protocol.calcite.DDLCreateTableRequest;
+import com.blazingdb.protocol.message.HeaderMessage;
+import com.blazingdb.protocol.message.RequestMessage;
+
+import blazingdb.protocol.orchestrator.MessageType;
+import com.blazingdb.protocol.message.ResponseErrorMessage;
+import com.blazingdb.protocol.message.ResponseMessage;
+import com.blazingdb.protocol.message.calcite.DDLCreateTableRequestMessage;
+import com.blazingdb.protocol.message.calcite.SchemaListMessage;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
+import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
-
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.UnknownHostException;
 
 public class TCPService implements Runnable {
 
 	private Integer tcpPort;
 	private String dataDirectory;
+	private String orchestratorIp;
+	private int orchestratorPort;
 
-	public TCPService(final Integer tcpPort, final String dataDirectory) {
+	public TCPService(final Integer tcpPort, final String dataDirectory, String orchestratorIp, int  orchestratorPort) {
+		this.orchestratorIp = orchestratorIp;
+		this.orchestratorPort = orchestratorPort;
 		this.tcpPort = tcpPort;
 		this.dataDirectory = dataDirectory;
+		try {
+			this.synchronizeSchema();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void synchronizeSchema() throws Exception {
+		TCPClient client = new TCPClient(orchestratorIp, orchestratorPort);
+		HeaderMessage header = new HeaderMessage(MessageType.SchemaList, 0L);
+		RequestMessage message = new RequestMessage(header);
+		ByteBuffer  responseBuffer = client.send( message.getBufferData());
+		ResponseMessage response = new ResponseMessage(responseBuffer);
+
+		if (response.getStatus() == Status.Error) {
+			ResponseErrorMessage responsePayload = new ResponseErrorMessage(response.getPayload());
+			System.out.println(responsePayload.getError());
+		}
+		SchemaListMessage responsePayload = new SchemaListMessage(response.getPayload());
+
+		System.out.println("synchronizeSchema, total: " + responsePayload.getSchemas().size());
+		ApplicationContext.getCatalogService(dataDirectory).dropAllTables();
+
+		if (responsePayload.getSchemas().size() > 0) {
+			String dbName = responsePayload.getSchemas().get(0).getDbName();
+			System.out.println("dbName from orch: " + dbName);
+			for (DDLCreateTableRequestMessage schema : responsePayload.getSchemas()) {
+				ApplicationContext.getCatalogService(dataDirectory).createTable(schema);
+				// I am unsure at this point if we have to update the schema or not but for safety I do it here
+				// need to see what hibernate moves around :)
+				ApplicationContext.updateContext(dataDirectory);
+			}
+		}
 	}
 
 	public static int bytesToInt(byte[] bytes) {

--- a/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/catalog/connection/CatalogServiceImpl.java
+++ b/blazingdb-calcite-application/src/main/java/com/blazingdb/calcite/catalog/connection/CatalogServiceImpl.java
@@ -1,6 +1,9 @@
 package com.blazingdb.calcite.catalog.connection;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import com.blazingdb.calcite.catalog.domain.CatalogDatabaseImpl;
 import com.blazingdb.calcite.catalog.domain.CatalogSchemaImpl;
@@ -13,8 +16,9 @@ import com.blazingdb.protocol.message.calcite.DDLDropTableRequestMessage;
 public class CatalogServiceImpl {
 
 	DatabaseRepository repo;
-	
+	Set<String> dbNames;
 	public CatalogServiceImpl(final String dataDirectory) {
+		dbNames = new HashSet<>();
 		repo = new DatabaseRepository(dataDirectory);
 	}
 	
@@ -30,7 +34,16 @@ public class CatalogServiceImpl {
 		CatalogDatabaseImpl db = repo.getDatabase(message.getDbName());
 		db.removeTable(message.getName());
 		repo.updateDatabase(db);
+	}
 
+	public void dropAllTables() {
+		for (String dbName : this.dbNames) {
+			CatalogDatabaseImpl db = repo.getDatabase(dbName);
+			for (String tableName : db.getTableNames()) {
+				db.removeTable(tableName);
+			}
+			repo.updateDatabase(db);
+		}
 	}
 	
 	public CatalogSchemaImpl getSchema(String schemaName) {
@@ -57,7 +70,7 @@ public class CatalogServiceImpl {
 
 	public void createDatabase(CatalogDatabaseImpl db) {
 		repo.createDatabase(db);
-		
+		dbNames.add(db.getDatabaseName());
 	}
 
 }


### PR DESCRIPTION
when calcite starts up, it should check its local orchestrator assuming port 8890 and make a request to get all of the schemas in the orchestrator.

 Este feature  lo que hacer es sincronizar el estado del registro de esquemas del orchestrator hacia calcite.  Es util si por ejemplo calcite tiene un estado incosistente en su BD debido algun reinicio. Entonces cada vez que reinicia calcite pregunta al orchetrator por los esquemas de las tablas registradas.
Nota. Para que funcione la communicacion de calcite hacia orchestrator, he agregado un par de parametros al jar de calcite, el ip (--orch_ip) y port (--orch_port) del orchestrator, por defecto toma estos valores ("127.0.0.1", "8889"). 
